### PR TITLE
 Fix UnrecognizedClientException In State Lock Acquisition

### DIFF
--- a/scylladb.tf
+++ b/scylladb.tf
@@ -109,7 +109,7 @@ data "cloudinit_config" "scyllaDB" {
       write_files = [
         {
           content = <<-EOT
-              FROM scylladb/scylla:latest
+              FROM scylladb/scylla:5.2.8
               RUN echo "alternator_enforce_authorization: true" >> /etc/scylla/scylla.yaml
               ENTRYPOINT ["/docker-entrypoint.py"]
             EOT
@@ -145,7 +145,7 @@ data "cloudinit_config" "scyllaDB" {
                     - "9042:9042"
 
                 scylladb-load-user:
-                  image: "scylladb/scylla:latest"
+                  image: "scylladb/scylla:5.2.8"
                   container_name: "scylladb-load-user"
                   depends_on:
                     - scylladb


### PR DESCRIPTION
This PR resolves the issue where the state lock could not be acquired due to a DynamoDB authentication error. The error encountered was an UnrecognizedClientException indicating that the user was not found, which resulted in a failure to retrieve and store the lock item in the DynamoDB table.

Changes:
Updated the ScyllaDB to 5.x version instead of latest image, system_auth.roles table has been deleted from versions 6.x.
The code now is working fine, inserting the user into roles table without getting `"unconfigured table roles"`  error message.